### PR TITLE
Added _phantomChildren to dependencies lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ function getTransitiveDependencies({ cwd }, dependencies, module) {
     if (!dependencies.find(d => d === module)) {
         dependencies.push(module);
         return getPackageInfo(at('node_modules/'+module+'/package.json'))
-            .then(modulePackage => Object.keys(modulePackage.dependencies || {}))
+            .then(modulePackage => Object.keys(modulePackage.dependencies || {})
+                                    .concat(Object.keys(modulePackage._phantomChildren || {})))
             .then(deps => { 
             	return Promise.map(deps, (dep) => { 
                		return getTransitiveDependencies({ cwd }, dependencies, dep);
@@ -66,7 +67,8 @@ function getPackageDependencies({ cwd }) {
     let at = resolvePathRelativeTo(cwd);
 	
     return getPackageInfo(at('package.json'))
-        .then(rootPackage => Object.keys(rootPackage.dependencies || {}))
+        .then(rootPackage => Object.keys(rootPackage.dependencies || {})
+                                .concat(Object.keys(rootPackage._phantomChildren || {})))
         .then(rootDependencies => {
 			let totalDependencies = [];            
         	return Promise.all(rootDependencies.map(dep => getTransitiveDependencies({ cwd }, totalDependencies, dep)))


### PR DESCRIPTION
There were still dependencies missing when deploying the packed Lambda, the dependencies in question were found in _phantomChildren, therefore this PR fixes that. Please let me know if this approach is acceptable and if you would be happy to accept. 